### PR TITLE
Automate the handling of duplicate channels

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ require('dotenv').config();
 const express = require('express');
 const bodyParser = require('body-parser');
 const events = require('./events');
+const utils = require('./utils');
 
 const app = express();
 
@@ -73,6 +74,11 @@ app.post('/events', (req, res) => {
         switch(event.type){
           case 'channel_created': {
             events.newChannel(event.channel.name);
+            if (utils.isDuplicateChannel(event.channel.name)){
+              events.notifyUserDuplicateChannel(event.channel.name);
+              events.archiveChannel(event.channel.name);
+              events.notifyAdminsDuplicateChannel(event.channel.name);
+            }
             break;
           } case 'team_join': {
             events.onboard(event.user.id);

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,39 @@
+
+const CLASS_CHANNELS = [
+  "161",
+  "162",
+  "165",
+  "199",
+  "225",
+  "261",
+  "271",
+  "290",
+  "312",
+  "321",
+  "325",
+  "340",
+  "344",
+  "352",
+  "361",
+  "362",
+  "372",
+  "373",
+  "381",
+  "382",
+  "440",
+  "444_544",
+  "450",
+  "461",
+  "464",
+  "467",
+  "472",
+  "475",
+  "492",
+  "493",
+  "496"
+]
+
+export const isDuplicateChannel = (channelName) => CLASS_CHANNELS.includes(normalizeChannelName(channelName));
+
+// Matches CS..., CS_..., or any lowercase variations there of
+export const normalizeChannelName = (channelName) => channelName.replace(/cs_?/i, '');


### PR DESCRIPTION
**Description**
On occasion, users will attempt to make a channel for a class even though it already exists. In the example below, the channel for CS225 is #225
![Screen Shot 2019-03-18 at 5 33 53 PM](https://user-images.githubusercontent.com/13680789/54565317-4b66c000-49a4-11e9-9888-91c572cc0bac.png)

**Acceptance Criteria**
When a new channel is created for any of the numeric class channels but is prepended with CS or cs or cs_ or CS_ 
- [ ] Post a message in the duplicate channel directing the user to the real channel and that this one will be archived
- [ ] Archive the duplicate channel
- [ ] Notify the admins that the channel has been taken care of

**Testing Plan**
1. Check out this branch in testing
2. Create the channel "CS161"
3. Confirm the 3 acceptance criteria have been met
4. Create the channel "CS162_group_6"
4. Confirm none of the acceptance criteria have been met